### PR TITLE
Fix path in npm@3+

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,2 +1,4 @@
 #!/usr/bin/env node
-require('../node_modules/typescript/lib/tsc.js')
+var path = require('path');
+
+require(path.join(path.dirname(require.resolve('typescript')), 'tsc.js'));


### PR DESCRIPTION
Fixes issue in npm@3+ as explained here: Microsoft/vscode-generator-code-extension#14.

This is untested at npm@2 but I don't see any reason why this shouldn't work.
