### PR TITLE
Fix Issue #12

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -63,7 +63,7 @@ function getURLMatchingEngine(engine, callback) {
             exitWithError(error);
         }
 
-        var tags = JSON.parse(tagsRaw).map(function (tag) { return tag.name; });
+        var tags = new Array(JSON.parse(tagsRaw)).map(function (tag) { return tag.name; });
         var tag = minSatisfying(tags, engine);
 
         // check if master is on the version specified


### PR DESCRIPTION
It seems in some cases `JSON.parse()` is returning an array, but not an instance of `Array`. I wrapped the existing `JSON.parse()` call in an `Array` constructor to ensure we always have the `map()` method available to us.