### PR TITLE
Enhancement - VSCode installations during test execution

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -5,6 +5,7 @@ var vzip = require('gulp-vinyl-zip');
 var symdest = require('gulp-symdest');
 var path = require('path');
 var cp = require('child_process');
+var fs = require('fs');
 
 var darwinZipName = 'VSCode-darwin.zip';
 var linuxZipName = 'VSCode-linux64.zip';
@@ -21,13 +22,8 @@ var testsWorkspace = process.env.CODE_TESTS_WORKSPACE || '';
 
 console.log('### VS Code Extension Test Run ###');
 console.log('Current working directory: ' + process.cwd());
-console.log('Downloading VS Code into "' + path.join(process.cwd(), testRunFolder) + '" from: ' + downloadUrl);
 
-var stream = remote(downloadUrl, { base: '' })
-    .pipe(vzip.src())
-    .pipe(symdest(testRunFolder));
-
-stream.on('end', function () {
+function runTests () {
     var executable = process.platform === 'darwin' ? darwinExecutable : linuxExecutable;
     var args = [
         testsFolder,
@@ -58,4 +54,22 @@ stream.on('end', function () {
             process.exit(code); // propagate exit code to outer runner
         }
     });
+}
+
+function downloadExecutableAndRunTests () {
+    console.log('Downloading VS Code into "' + path.join(process.cwd(), testRunFolder) + '" from: ' + downloadUrl);
+
+    var stream = remote(downloadUrl, { base: '' })
+        .pipe(vzip.src())
+        .pipe(symdest(testRunFolder));
+
+    stream.on('end', runTests);
+}
+
+fs.exists(testRunFolder, function (exists) {
+    if (exists) {
+        runTests();
+    } else {
+        downloadExecutableAndRunTests();
+    }
 });


### PR DESCRIPTION
This change only installs VSCode when it has not yet been installed when running tests.

I noticed when running tests in https://github.com/Microsoft/vscode-react-native/pull/92 that it would fail the second time due to the VSCode install path already existing. It become clear every time a test was run, VSCode would be downloaded and installed, but run into trouble if it is _already installed_.

```
npm test

> vscode-react-native@0.1.0 test /Users/ajwhite/Development/Labs/Forks/vscode-react-native
> node ./node_modules/vscode/bin/test

### VS Code Extension Test Run ###
Current working directory: /Users/ajwhite/Development/Labs/Forks/vscode-react-native
Downloading VS Code into "/Users/ajwhite/Development/Labs/Forks/vscode-react-native/.vscode-test" from: https://az764295.vo.msecnd.net/public/0.10.5/VSCode-darwin.zip
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: EEXIST: file already exists, symlink 'Versions/Current/Electron Framework' -> '.vscode-test/Visual Studio Code.app/Contents/Frameworks/Electron Framework.framework/Electron Framework'
    at Error (native)
npm ERR! Test failed.  See above for more details.
```

This change verifies the `testRunFolder` path does not exist before performing the download. 

**If the path exists**, no download occurs, tests run.

**If the path does not exist**, the VS Code executable is downloaded and then the tests run, just like they previously did.

----

Successful output from `vscode-react-native` after these changes when running tests:

```
npm test

> vscode-react-native@0.1.0 test /Users/ajwhite/Development/Labs/Forks/vscode-react-native
> node ./node_modules/vscode/bin/test

### VS Code Extension Test Run ###
Current working directory: /Users/ajwhite/Development/Labs/Forks/vscode-react-native
Running extension tests: /Users/ajwhite/Development/Labs/Forks/vscode-react-native/.vscode-test/Visual Studio Code.app/Contents/MacOS/Electron /Users/ajwhite/Development/Labs/Forks/vscode-react-native/out/test --extensionDevelopmentPath=/Users/ajwhite/Development/Labs/Forks/vscode-react-native --extensionTestsPath=/Users/ajwhite/Development/Labs/Forks/vscode-react-native/out/test



  reactDirManager.ts

    ReactDirPath
      ✓ Should end with the correct path to the react folder





  1 passing (4ms)



Loading development extension at /Users/ajwhite/Development/Labs/Forks/vscode-react-native

[/Users/ajwhite/Development/Labs/Forks/vscode-react-native]: Overwriting extension /Users/ajwhite/.vscode/extensions/vscode-react-native with /Users/ajwhite/Development/Labs/Forks/vscode-react-native

Tests exited with code: 0
```
