### PR TITLE
retrieve the commit hash from the tag of the vscode repository

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,48 +1,19 @@
 #!/usr/bin/env node
 
-var remote = require('gulp-remote-src');
-var vzip = require('gulp-vinyl-zip');
-var symdest = require('gulp-symdest');
 var path = require('path');
 var cp = require('child_process');
 var fs = require('fs');
+var remote = require('gulp-remote-src');
+var vzip = require('gulp-vinyl-zip');
+var symdest = require('gulp-symdest');
+var ghGot = require('gh-got');
+var parse = require('github-parse-link');
+var semver = require('semver');
 
 var testRunFolder = '.vscode-test';
 var testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
 var darwinExecutable = path.join(testRunFolderAbsolute, 'Visual Studio Code.app', 'Contents', 'MacOS', 'Electron');
 var linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'code');
-
-var downloadUrl = process.env.CODE_DOWNLOAD_URL;
-if (!downloadUrl) {
-    var version = process.env.CODE_VERSION || '0.10.10';
-    var filename;
-    if (['0.10.1', '0.10.2', '0.10.3', '0.10.4', '0.10.5', '0.10.6', '0.10.7', '0.10.8', '0.10.9'].indexOf(version) >= 0) {
-        filename = (process.platform === 'darwin') ? 'VSCode-darwin.zip' : 'VSCode-linux64.zip';
-        linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'Code');
-    } else {
-        filename = (process.platform === 'darwin') ? 'VSCode-darwin-stable.zip' : 'VSCode-linux-x64-stable.zip';
-    }
-
-    var commit;
-
-    switch (version) {
-        case '0.10.10': commit = '5b5f4db87c10345b9d5c8d0bed745bcad4533135'; break;
-        case '0.10.9': commit = '45d69357c9eb068dd8e624f5b0fe461cd2078d88'; break;
-        case '0.10.8': commit = 'db71ac615ddf9f33b133ff2536f5d33a77d4774e'; break;
-        case '0.10.7': commit = 'a39f3c4b27abf74b073940ee3d646beda0413118'; break;
-    }
-
-    // Post 0.10.6
-    if (commit) {
-        downloadUrl = ['https://az764295.vo.msecnd.net/stable', commit, filename].join('/');
-    }
-
-    // Pre 0.10.7
-    else {
-        downloadUrl = ['https://az764295.vo.msecnd.net/public', version, filename].join('/');
-    }
-}
-
 
 var testsFolder;
 if (process.env.CODE_TESTS_PATH) {
@@ -57,6 +28,81 @@ var testsWorkspace = process.env.CODE_TESTS_WORKSPACE || testsFolder;
 
 console.log('### VS Code Extension Test Run ###');
 console.log('Current working directory: ' + process.cwd());
+
+// Recursively load the tags of all the pages
+function getTags(url, tags) {
+    var tags = tags || [];
+
+    return ghGot(url || 'repos/Microsoft/vscode/tags')
+        .then(function(result) {
+            var link = parse(result.headers.link);
+            tags = tags.concat(result.body);
+
+            if (link.next) {
+                return getTags(link.next, tags);
+            }
+
+            return tags;
+        });
+}
+
+function getDownloadUrl() {
+    if (process.env.CODE_DOWNLOAD_URL) {
+        return Promise.resolve(process.env.CODE_DOWNLOAD_URL);
+    }
+
+    return getTags()
+        .then(function(tags) {
+            // Filter out invalid tags and prerelease tags
+            tags = tags.filter(function(tag) {
+                var parsed = semver.parse(tag.name);
+                return parsed && parsed.prerelease.length === 0;
+            });
+
+            // Use the latest version as default
+            var version = process.env.CODE_VERSION || tags[0].name;
+
+            // Create a tags map
+            var tagMap = tags.reduce(function(map, tag) {
+                if (semver.valid(tag.name)) {
+                    map[tag.name] = tag;
+                }
+
+                return map;
+            }, {});
+
+            var tag = tagMap[version];
+            var filename;
+
+            if (semver.lt(version, '0.10.10')) {
+                filename = (process.platform === 'darwin') ? 'VSCode-darwin.zip' : 'VSCode-linux64.zip';
+                linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'Code');
+            } else {
+                filename = (process.platform === 'darwin') ? 'VSCode-darwin-stable.zip' : 'VSCode-linux-x64-stable.zip';
+            }
+
+            // Post 0.10.6
+            if (tag && semver.gt(version, '0.10.6')) {
+                return ['https://az764295.vo.msecnd.net/stable', tag.commit.sha, filename].join('/');
+            }
+
+            // Pre 0.10.7
+            return ['https://az764295.vo.msecnd.net/public', version, filename].join('/');
+        });
+}
+
+function downloadExecutable(downloadUrl) {
+    console.log('Downloading VS Code into "' + testRunFolderAbsolute + '" from: ' + downloadUrl);
+
+    return new Promise(function(resolve, reject) {
+        var stream = remote(downloadUrl, { base: '' })
+            .pipe(vzip.src())
+            .pipe(symdest(testRunFolder));
+
+        stream.on('error', reject);
+        stream.on('end', resolve);
+    });
+}
 
 function runTests() {
     var executable = process.platform === 'darwin' ? darwinExecutable : linuxExecutable;
@@ -91,20 +137,16 @@ function runTests() {
     });
 }
 
-function downloadExecutableAndRunTests() {
-    console.log('Downloading VS Code into "' + testRunFolderAbsolute + '" from: ' + downloadUrl);
-
-    var stream = remote(downloadUrl, { base: '' })
-        .pipe(vzip.src())
-        .pipe(symdest(testRunFolder));
-
-    stream.on('end', runTests);
-}
-
 fs.exists(testRunFolderAbsolute, function(exists) {
     if (exists) {
         runTests();
-    } else {
-        downloadExecutableAndRunTests();
+        return;
     }
+
+    getDownloadUrl()
+        .then(downloadExecutable)
+        .then(runTests)
+        .catch(function(err) {
+            console.error(err.stack);
+        });
 });

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
-    "name": "vscode",
-    "version": "0.11.8",
-    "typings": "vscode.d.ts",
-    "scripts": {
-        "prepublish": "tsc"
-    },
-    "dependencies": {
-        "mocha": "^2.3.3",
-        "glob": "^5.0.15",
-        "request": "^2.67.0",
-        "semver": "^5.1.0",
-        "source-map-support": "^0.3.2",
-        "gulp-remote-src": "^0.4.0",
-        "gulp-vinyl-zip": "^1.1.2",
-        "gulp-symdest": "^1.0.0"
-    },
-    "license": "MIT",
-    "author": "Visual Studio Code Team",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
-    },
-    "bugs": {
-        "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"
-    }
+  "name": "vscode",
+  "version": "0.11.8",
+  "typings": "vscode.d.ts",
+  "scripts": {
+    "prepublish": "tsc"
+  },
+  "dependencies": {
+    "gh-got": "^2.4.0",
+    "github-parse-link": "^1.1.1",
+    "glob": "^5.0.15",
+    "gulp-remote-src": "^0.4.0",
+    "gulp-symdest": "^1.0.0",
+    "gulp-vinyl-zip": "^1.1.2",
+    "mocha": "^2.3.3",
+    "request": "^2.67.0",
+    "semver": "^5.1.0",
+    "source-map-support": "^0.3.2"
+  },
+  "license": "MIT",
+  "author": "Visual Studio Code Team",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"
+  }
 }


### PR DESCRIPTION
As "discussed" in the commit [here](https://github.com/Microsoft/vscode-extension-vscode/commit/f621005b4edbac5a381e1ab97940e6c2c76644cb#commitcomment-16557298), I changed the implementation of the `test` file. Instead of hard-coding the commit hashes, I retrieve the tags via the GitHub API.

I also refactored the flow to use promises (I hate callbacks to be honest :)). But this could be nice for the future if you want to extend the behaviour, you can just add extra steps in the promise chain.

I also used [gh-got](https://github.com/sindresorhus/gh-got) to interact with the GitHub API. `gh-got` is a small wrapper around [got](https://github.com/sindresorhus/got) which serves the same purpose as `request` but was create because `request` got bloated with too many features. But it offers a nice interface to the GitHub API and has built-in support for the `GITHUB_TOKEN` environment variable.

Just let me know what you think. Please provide feedback if you think things should be done differently, or in a better way. If you don't like it, no harm done :).