### PR TITLE
Support extracting .tar.gz on Linux builds

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -77,7 +77,7 @@ function downloadExecutableAndRunTests() {
         console.log('Downloading VS Code into "' + testRunFolderAbsolute + '" from: ' + downloadUrl);
 
         var version = downloadUrl.match(/\d\.\d\.\d/)[0].split('\.');
-        var isTarGz = downloadUrl.match(/linux/) && version[0] >= 1 && version[1] >= 4;
+        var isTarGz = downloadUrl.match(/linux/) && version[0] >= 1 && version[1] >= 5;
 
         var stream;
         if (isTarGz) {

--- a/bin/test
+++ b/bin/test
@@ -3,10 +3,14 @@
 var remote = require('gulp-remote-src');
 var vzip = require('gulp-vinyl-zip');
 var symdest = require('gulp-symdest');
+var untar = require('gulp-untar');
+var gunzip = require('gulp-gunzip');
 var path = require('path');
 var cp = require('child_process');
 var fs = require('fs');
 var shared = require('../lib/shared');
+var request = require('request');
+var source = require('vinyl-source-stream');
 
 var testRunFolder = '.vscode-test';
 var testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
@@ -72,9 +76,21 @@ function downloadExecutableAndRunTests() {
     getDownloadUrl(function (downloadUrl) {
         console.log('Downloading VS Code into "' + testRunFolderAbsolute + '" from: ' + downloadUrl);
 
-        var stream = remote(downloadUrl, { base: '' })
-            .pipe(vzip.src())
-            .pipe(symdest(testRunFolder));
+        var version = downloadUrl.match(/\d\.\d\.\d/)[0].split('\.');
+        var isTarGz = downloadUrl.match(/linux/) && version[0] >= 1 && version[1] >= 4;
+
+        var stream;
+        if (isTarGz) {
+            stream = request(downloadUrl)
+                .pipe(source(path.basename(downloadUrl)))
+                .pipe(gunzip())
+                .pipe(untar())
+                .pipe(symdest(testRunFolder));
+        } else {
+            stream = remote(downloadUrl, { base: '' })
+                .pipe(vzip.src())
+                .pipe(symdest(testRunFolder));
+        }
 
         stream.on('end', runTests);
     });

--- a/package.json
+++ b/package.json
@@ -1,27 +1,30 @@
 {
-    "name": "vscode",
-    "version": "0.11.14",
-    "typings": "vscode.d.ts",
-    "scripts": {
-        "prepublish": "tsc"
-    },
-    "dependencies": {
-        "mocha": "^2.3.3",
-        "glob": "^5.0.15",
-        "request": "^2.67.0",
-        "semver": "^5.1.0",
-        "source-map-support": "^0.3.2",
-        "gulp-remote-src": "^0.4.0",
-        "gulp-vinyl-zip": "^1.1.2",
-        "gulp-symdest": "^1.0.0"
-    },
-    "license": "MIT",
-    "author": "Visual Studio Code Team",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
-    },
-    "bugs": {
-        "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"
-    }
+  "name": "vscode",
+  "version": "0.11.14",
+  "typings": "vscode.d.ts",
+  "scripts": {
+    "prepublish": "tsc"
+  },
+  "dependencies": {
+    "mocha": "^2.3.3",
+    "glob": "^5.0.15",
+    "request": "^2.67.0",
+    "semver": "^5.1.0",
+    "source-map-support": "^0.3.2",
+    "gulp-remote-src": "^0.4.0",
+    "gulp-vinyl-zip": "^1.1.2",
+    "gulp-symdest": "^1.0.0",
+    "gulp-gunzip": "0.0.3",
+    "gulp-untar": "0.0.4",
+    "vinyl-source-stream": "^1.1.0"
+  },
+  "license": "MIT",
+  "author": "Visual Studio Code Team",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"
+  }
 }


### PR DESCRIPTION
Fixes Microsoft/vscode#7308

---

Notes:

- I tried to get it working using `gulp-remote-src` first but it always seemed to extract the files into `.vscode-test/https\:/vscode-update.azurewebsites.net/1.4.0-insider/linux-x64/VSCode-linux-x64/`, that's why I introduced `vinyl-source-stream`.
- Currently it's set to work on 1.4.0 and beyond, this can be pushed back to 1.5.0 if you're not back until then.
- Should be pushed along with a https://github.com/Microsoft/vscode-distro change just before the release.