### PR TITLE
Add CODE_EXTENSIONS_PATH env var

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -38,6 +38,7 @@ if (process.env.CODE_TESTS_PATH) {
 }
 
 var testsWorkspace = process.env.CODE_TESTS_WORKSPACE || testsFolder;
+var extensionsFolder = process.env.CODE_EXTENSIONS_PATH || process.cwd();
 
 console.log('### VS Code Extension Test Run ###');
 console.log('Current working directory: ' + process.cwd());
@@ -46,7 +47,7 @@ function runTests() {
     var executable = (process.platform === 'darwin') ? darwinExecutable  : process.platform === 'win32' ? windowsExecutable : linuxExecutable;
     var args = [
         testsWorkspace,
-        '--extensionDevelopmentPath=' + process.cwd(),
+        '--extensionDevelopmentPath=' + extensionsFolder,
         '--extensionTestsPath=' + testsFolder
     ];
 


### PR DESCRIPTION
This allows us to also point to a folder with all the extensions that need to be part of the tests (for integration/systems types tests).

I'll open another PR for updating https://code.visualstudio.com/docs/extensions/testing-extensions#_running-tests-automatically-on-travis-ci-build-machines to include the new env var.

Resolves #70. 