### PR TITLE
Fix strict ssl setting due to npm bug to re-fix #57

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -17,7 +17,9 @@ function getContents(url, token, headers, callback) {
         url: url,
         headers: headers
     };
-    if (process.env.npm_config_strict_ssl === 'false') {
+    // We need to test the absence of true here because there is an npm bug that will not set boolean
+    // env variables if they are set to false.
+    if (process.env.npm_config_strict_ssl !== 'true') {
         options.strictSSL = false;
     }
     if (process.env.npm_config_proxy && parsedUrl.protocol === 'http:') {

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -23,7 +23,9 @@ export function getContents(url, token, headers, callback) {
         headers: headers
     };
 
-    if (process.env.npm_config_strict_ssl === 'false') {
+    // We need to test the absence of true here because there is an npm bug that will not set boolean
+    // env variables if they are set to false.
+    if (process.env.npm_config_strict_ssl !== 'true') {
         options.strictSSL = false;
     }
 


### PR DESCRIPTION
This fixes the npm bug where boolean config values that are set to false do not make it to env variables (fixes #57).