### PR TITLE
added bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./"
   },
+  "bin": {
+    "vscode-install": "./bin/install"
+  },
   "dependencies": {
     "glob": "^7.1.1",
     "gulp-chmod": "^2.0.0",


### PR DESCRIPTION
Hi, I added `install` to the `"bin"` in `package.json`. I'd like to get rid of the hard coded path used in the [lsp-sample](https://github.com/Microsoft/vscode-extension-samples/blob/master/lsp-sample/client/package.json#L51) (and my own projects). As you know the path can be a little bit error prone between different npm clients and projects structures. (I currently use yarn with workspaces for a VS Code extension and it looks really nice. This is just on of those small gotchas I found.)