### PR TITLE
Fix invalid permission on Linux

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -91,7 +91,7 @@ function downloadExecutableAndRunTests() {
                 .pipe(gunzip())
                 .pipe(untar())
 				.pipe(gulpFilter)
-				.pipe(chmod(755))
+				.pipe(chmod(0o755))
 				.pipe(gulpFilter.restore)
                 .pipe(symdest(testRunFolder));
         } else {


### PR DESCRIPTION
On Linux, the test runner for VSCode extensions uses invalid permissions (755 *decimal* => `-wxrw--wt`) for `VSCode-linux-x64/code`.
Although this does not prevent test because the owner has 'x' permission (accidentally), this causes failure of caching by CI.

For example:
* https://travis-ci.org/kimushu/rubic-vscode/jobs/302262680
  * Test succeeded at [L1466](https://travis-ci.org/kimushu/rubic-vscode/jobs/302262680#L1466)
  * `code` has invalid permission at [L1478](https://travis-ci.org/kimushu/rubic-vscode/jobs/302262680#L1478)
  * Making cache failed at [L1514](https://travis-ci.org/kimushu/rubic-vscode/jobs/302262680#L1514)

Improved by this patch:
* https://travis-ci.org/kimushu/rubic-vscode/jobs/302270218
  * Patched at [L1263](https://travis-ci.org/kimushu/rubic-vscode/jobs/302270218#L1263)
  * Test succeeded at [L1466](https://travis-ci.org/kimushu/rubic-vscode/jobs/302270218#L1466)
  * `code` has *valid* permission at [L1478](https://travis-ci.org/kimushu/rubic-vscode/jobs/302270218#L1478)
  * Making cache *succeeded* at [L1513](https://travis-ci.org/kimushu/rubic-vscode/jobs/302270218#L1513)