### PR TITLE
Check for presence of code executable instead of just folder

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -50,12 +50,12 @@ if (process.env.CODE_TESTS_PATH) {
 
 var testsWorkspace = process.env.CODE_TESTS_WORKSPACE || testsFolder;
 var extensionsFolder = process.env.CODE_EXTENSIONS_PATH || process.cwd();
+var executable = (process.platform === 'darwin') ? darwinExecutable : process.platform === 'win32' ? windowsExecutable : linuxExecutable;
 
 console.log('### VS Code Extension Test Run ###');
 console.log('Current working directory: ' + process.cwd());
 
 function runTests() {
-    var executable = (process.platform === 'darwin') ? darwinExecutable : process.platform === 'win32' ? windowsExecutable : linuxExecutable;
     var args = [
         testsWorkspace,
         '--extensionDevelopmentPath=' + extensionsFolder,
@@ -143,7 +143,7 @@ function getTag(clb) {
     });
 }
 
-fs.exists(testRunFolderAbsolute, function (exists) {
+fs.exists(executable, function (exists) {
     if (exists) {
         runTests();
     } else {


### PR DESCRIPTION
This fixes the issue of running tests against both stable/insiders versions failing because the folder exists after one download but the executable is then missing for the next).

I can't see any automated tests for this but the vest way to manually test is:

- Open terminal for an extension that has tests
- Delete `.vscode-test` folder
- Set `CODE_VERSION` to `*`
- Run `npm test`
- Ensure stable VS Code was downloaded and then used to execute tests
- Set `CODE_VERSION` to `insiders`
- Run `npm test`
- Observe error message caused by trying to run Insiders code without downloading it

This change changes the exists check to look for the executable so that it will download the insiders version.

Note: This change does NOT handle a version mismatch between what's already in `.vscode-test` and what's available (I'll raise another issue about that, but that's less important than this IMO because it doesn't break the common case where you want to run tests in stable/insiders on Travis/AppVeyor because they start without a `.vscode-test` folder.

Fixes #94.