### PR TITLE
Place VS Code inside insiders/stable sub-folders of .vs-test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -14,11 +14,11 @@ var shared = require('../lib/shared');
 var request = require('request');
 var source = require('vinyl-source-stream');
 
-var testRunFolder = '.vscode-test';
-var testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
-
 var version = process.env.CODE_VERSION || '*';
 var isInsiders = version === 'insiders';
+
+var testRunFolder = path.join('.vscode-test', isInsiders ? 'insiders' : 'stable');
+var testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
 
 var downloadPlatform = (process.platform === 'darwin') ? 'darwin' : process.platform === 'win32' ? 'win32-archive' : 'linux-x64';
 


### PR DESCRIPTION
This avoids files overwriting each other from each version on Windows which might cause issues if you run tests for stable, then insiders, then stable again.

Slightly related to #94.

I've tested on Windows and Mac OS but don't have easy access to a Linux machine (the change is fairly trivial, however).

This could break people if they're relying on the executable being in a specific location in other scripts, but this seems very unlikely (and the fix is fairly obvious if it does break you).