### PR TITLE
Don't download Code every time on Windows

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -27,11 +27,11 @@ var darwinExecutable;
 var linuxExecutable;
 
 if (isInsiders) {
-    windowsExecutable = path.join(testRunFolderAbsolute, 'Code - Insiders');
+    windowsExecutable = path.join(testRunFolderAbsolute, 'Code - Insiders.exe');
     darwinExecutable = path.join(testRunFolderAbsolute, 'Visual Studio Code - Insiders.app', 'Contents', 'MacOS', 'Electron');
     linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'code-insiders');
 } else {
-    windowsExecutable = path.join(testRunFolderAbsolute, 'Code');
+    windowsExecutable = path.join(testRunFolderAbsolute, 'Code.exe');
     darwinExecutable = path.join(testRunFolderAbsolute, 'Visual Studio Code.app', 'Contents', 'MacOS', 'Electron');
     linuxExecutable = path.join(testRunFolderAbsolute, 'VSCode-linux-x64', 'code');
     if (['0.10.1', '0.10.2', '0.10.3', '0.10.4', '0.10.5', '0.10.6', '0.10.7', '0.10.8', '0.10.9'].indexOf(version) >= 0) {


### PR DESCRIPTION
The `exists` check further down fails to find the executable on Windows because the real filename has `.exe` on the end. This means it downloads over and over again (which can be significant if you run this script multiple times to test different workspace folders).

Fixes #100.