### PR TITLE
Add support for Mocha's forbidOnly

### DIFF
--- a/lib/testrunner.d.ts
+++ b/lib/testrunner.d.ts
@@ -29,5 +29,8 @@ declare module 'vscode/lib/testrunner' {
 
         // colored output from test results
         useColors?: boolean;
+
+        // causes test marked with only to fail the suite
+        forbidOnly?: boolean;
     }
 }


### PR DESCRIPTION
If this flag is set to true, the suite will be marked as failed if you use `describe.only` or `test.only`. If you set this conditionally from an ENV variable (for ex.) you can ensure your CI fails if someone accidentally commits a `.only`.

<img width="351" alt="screen shot 2018-03-22 at 12 32 33" src="https://user-images.githubusercontent.com/1078012/37770696-2e083258-2dcd-11e8-855f-c998711df7a4.png">

Example of it being used (but requires a cast): https://github.com/Dart-Code/Dart-Code/commit/323a50831a709a028ec9542a9e6ca56ddb75c6f9