### PR TITLE
Add strictSSL option, if npm strict-ssl is false

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -97,7 +97,14 @@ function downloadExecutableAndRunTests() {
         var stream;
         if (isTarGz) {
             var gulpFilter = filter(['VSCode-linux-x64/code', 'VSCode-linux-x64/code-insiders', 'VSCode-linux-x64/resources/app/node_modules*/vscode-ripgrep/**/rg'], { restore: true });
-            stream = request(downloadUrl)
+            var options = {
+                url: downloadUrl                
+            }
+            if (process.env.npm_config_strict_ssl !== 'true') {
+                options.strictSSL = false;
+            }
+            
+            stream = request(options)
                 .pipe(source(path.basename(downloadUrl)))
                 .pipe(gunzip())
                 .pipe(untar())


### PR DESCRIPTION
Pull request to solve issue #132 

I have modified it to run the vscode test in an environment where `strict-ssl:false` must be used.

Thank you for your review! :smile: 