### PR TITLE
Fix #149

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Visual Studio Code Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
+    "url": "https://github.com/Microsoft/vscode.git"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"


### PR DESCRIPTION
Without this each time I try to make the change as described in #149, dtslint fails for me on DefinitelyTyped:

![image](https://user-images.githubusercontent.com/4033249/54585248-cd6fdc80-49d6-11e9-92e4-fc7843399016.png)

Because `@types/vscode` and `vscode` has to point to the same project.

I just want to change this line: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/vscode/index.d.ts#L2

From:

```
// Project: https://github.com/microsoft/vscode-extension-vscode
```

to:

```
// Project: https://github.com/microsoft/vscode
```

So people who has F12'ed their way into the vscode.d.ts can find the correct project.
