### PR TITLE
fix(test): fix looking up or downloading the specified VSCode version

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -9,7 +9,7 @@ const downloadAndUnzipVSCode = require('vscode-test').downloadAndUnzipVSCode;
 const version = process.env.CODE_VERSION || '*';
 const isInsiders = version === 'insiders';
 
-const testRunFolder = path.join('.vscode-test', isInsiders ? 'insiders' : 'stable');
+const testRunFolder = path.join('.vscode-test', isInsiders ? 'insiders' : `vscode-${version}`);
 const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
 
 let windowsExecutable;

--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ const fs = require('fs');
 
 const downloadAndUnzipVSCode = require('vscode-test').downloadAndUnzipVSCode;
 
-const version = process.env.CODE_VERSION || '*';
+const version = process.env.CODE_VERSION || '<latest>';
 const isInsiders = version === 'insiders';
 
 const testRunFolder = path.join('.vscode-test', isInsiders ? 'insiders' : `vscode-${version}`);
@@ -91,7 +91,9 @@ function runTests() {
 function downloadExecutableAndRunTests() {
     console.log('Downloading VS Code into "' + testRunFolderAbsolute);
 
-    downloadAndUnzipVSCode().then(executablePath => {
+    var targetVersion = (version === '<latest>') ? undefined : version;
+
+    downloadAndUnzipVSCode(targetVersion).then(executablePath => {
         executable = executablePath
         runTests()
     })


### PR DESCRIPTION
Follow-up to #148. Includes the following fixes:

- Look for existing VSCode app in the correct directory.
  Previously, the `test` script would look for a `.vscode-test/stable/` directory, but since #148 VSCode will be downloaded to `.vscode-test/vscode-<VERSION>/`.

- Take `CODE_VERSION` into account when downloading VSCode.
  Previously, when the specified version was not already downloaded, `downloadAndUnzipVSCode()` would be called without any argument, thus always fetching the latest version and ignoring the value of the `CODE_VERSION` env variable.