### PR TITLE
Use an accurate repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "Visual Studio Code Team",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vscode.git"
+    "url": "https://github.com/Microsoft/vscode-extension-vscode.git"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-extension-vscode/issues"


### PR DESCRIPTION
👋 

This updates the "repository" field in `package.json` to point to _this_ repository, as opposed to [the main VSCode one](https://github.com/Microsoft/vscode).

The primary benefit here is that it will make this link on the npm package page point to the correct place:

<img width="1219" alt="Screen Shot 2019-05-30 at 10 21 55 AM" src="https://user-images.githubusercontent.com/17565/58639386-cc0b3c00-82c4-11e9-84a6-5ae4805850b2.png">

I just spent longer than I'd like to admit hunting for this source in the VSCode repository instead 😆 